### PR TITLE
Issue 35 - Added a professors table and a courses_to_professors table

### DIFF
--- a/ProjectSourceCode/src/init_data/create.sql
+++ b/ProjectSourceCode/src/init_data/create.sql
@@ -16,28 +16,51 @@ CREATE TABLE IF NOT EXISTS users (
   username VARCHAR(100) NOT NULL, /*display name for review, can have repeat usernames */
   password CHAR(60) NOT NULL
 );
+
 DROP TABLE IF EXISTS reviews;
 /* I was going to add date posted as an attribute, but we can query the date posted by the id number of the review (later posts will have a higher id number)
  *review, course name, and user id should not be optional. Also made review VARCHAR(8000) so they can write as much as they want*/
 CREATE TABLE reviews (
     review_id SERIAL PRIMARY KEY,
-    course_id int NOT NULL,
-    FOREIGN KEY (course_id) REFERENCES courses(id),
-    user_id int NOT NULL,
-    FOREIGN KEY (user_id) REFERENCES users(user_id),
+    /* could potentially be easier to sort the reviews by their timestamp (exactly when they were posted) but I'm not sure if that will overcomplicate things, we can still identify when the reviews was writen by its primary key */
+    course_id INT NOT NULL,
+    /* identify when exactly the user took the course */
+    year_taken SMALLINT NOT NULL,
+    term_taken CHAR(4) CHECK (term_taken in ('Fall', 'Spring', 'Summer')),  
+    /* Each review is associated with exactly one course and one user */
+    FOREIGN KEY (course_id) REFERENCES courses(id) ON DELETE CASCADE,
+    user_id INT NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE,
     review VARCHAR(8000) NOT NULL, 
-    overall_rating DECIMAL NOT NULL /* if we want to add more statistics, we can make this rating an average of all of them, just put it as one attribute here so we can decide on thsoe details later on */
-    
+    overall_rating DECIMAL NOT NULL CHECK (overall_rating between 0 and 10), /*We can make this rating be an average of all of the ratings metrics or leave the overall rating up to the user, right now I left it as just an overall rating out of 10*/
+    /* rating metrics - can add more later on*/
+    homework_rating DECIMAL CHECK (homework_rating between 0 and 10),
+    enjoyability_rating DECIMAL CHECK (enjoyability_rating between 0 and 10), /* How much the user enjoyed the course */
+    usefulness_rating DECIMAL CHECK (usefulness_rating between 0 and 10), /* how useful this course is to the user, i.e is the content in this course often used in this industry? does it apply to everday life? is it necessary to take to understand more useful classes later on? */
+    difficulty_rating DECIMAL CHECK (difficulty_rating between 0 and 10),
+    /* Tag each course review to a professor */
+    professor_id INT NOT NULL,
+    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE /* Each review should have exactly 1 professor associated with it*/
 );
-/*
-If we want to add the rate my professors feature, we can add this table to keep track of them. We would have to make it so
-each review also references a professor, and also so that each professor has courses that they are associated with. 
-I think the easiest way to connect professors to courses would be through a courses_to_professors table since a professor can have multiple courses that they teach
-DROP TABLE IF EXISTS users;
+
+/* Table to keep track of all of the professors listed on our interface. */
+DROP TABLE IF EXISTS professors;
 CREATE TABLE IF NOT EXISTS professors (
     professor_id SERIAL PRIMARY KEY NOT NULL,
     first_name VARCHAR(50),
     last_name VARCHAR(50),
-    years_teaching int
+    department VARCHAR(50), /* department that the professor is currently in */
+    years_teaching SMALLINT /* How many years the professor has been teaching for, could make this more specific to how many years they've taught at CU, how many years they've taught in this department, etc. */
 );
-*/
+
+/* table to connect professors to the courses they teach */
+DROP TABLE IF EXISTS courses_to_professors;
+CREATE TABLE IF NOT EXISTS courses_to_professors (
+    course_id INT NOT NULL,
+    professor_id INT NOT NULL,
+    FOREIGN KEY (course_id) REFERENCES courses (id) ON DELETE CASCADE,
+    FOREIGN KEY (professor_id) REFERENCES professors (professor_id) ON DELETE CASCADE
+);
+
+/* For the actual rate my professors side of this interface, we might need a separate reviews table that is specific to rating a professor 
+(would have different metrics like how engaging the professor is, how much the student learned, etc.) */

--- a/ProjectSourceCode/src/init_data/create.sql
+++ b/ProjectSourceCode/src/init_data/create.sql
@@ -26,7 +26,7 @@ CREATE TABLE reviews (
     course_id INT NOT NULL,
     /* identify when exactly the user took the course */
     year_taken SMALLINT NOT NULL,
-    term_taken CHAR(4) CHECK (term_taken in ('Fall', 'Spring', 'Summer')),  
+    term_taken VARCHAR(6) CHECK (term_taken in ('Fall', 'Spring', 'Summer')),  
     /* Each review is associated with exactly one course and one user */
     FOREIGN KEY (course_id) REFERENCES courses(id) ON DELETE CASCADE,
     user_id INT NOT NULL,
@@ -34,12 +34,22 @@ CREATE TABLE reviews (
     review VARCHAR(8000) NOT NULL, 
     overall_rating DECIMAL NOT NULL CHECK (overall_rating between 0 and 10), /*We can make this rating be an average of all of the ratings metrics or leave the overall rating up to the user, right now I left it as just an overall rating out of 10*/
     /* rating metrics - can add more later on*/
-    homework_rating DECIMAL CHECK (homework_rating between 0 and 10),
-    enjoyability_rating DECIMAL CHECK (enjoyability_rating between 0 and 10), /* How much the user enjoyed the course */
+    homework_rating DECIMAL CHECK (homework_rating between 0 and 10), /* prompt them to indicate how much time they spent outside of the class on assignments */
+    enjoyability_rating DECIMAL CHECK (enjoyability_rating between 0 and 10), /* How much the user enjoyed the course, did they find it interesting or boring */
     usefulness_rating DECIMAL CHECK (usefulness_rating between 0 and 10), /* how useful this course is to the user, i.e is the content in this course often used in this industry? does it apply to everday life? is it necessary to take to understand more useful classes later on? */
-    difficulty_rating DECIMAL CHECK (difficulty_rating between 0 and 10),
+    difficulty_rating DECIMAL CHECK (difficulty_rating between 0 and 10), /* generally how difficult they thought this course was */
+    /* grading metrics - grading breakdown of course, what was the student mainly graded on */
+    /*
+    grade_recieved CHAR(2) NOT NULL CHECK (grade_recieved in ('A', 'A-', ... )) don't know if check necessary if grade recieved is a drop down menu
+    grading_difficulty VARCHAR(1000) /*Allow users to provide an explanation into the grade they recieved, prompt them to explain the difficulty of grading and how hard they worked to recieve the grade they have (i.e was this class an easy A? did I work really hard for a B? were grade averages low?) */ 
+    attendance_required BOOL NOT NULL, /* Was attendence required/needed to get a good grade */
+    /* have user check one grading catagory */
+    exam_based BOOL, /* grade was mostly determined by exams */
+    project_based BOOL, /* grade was mostly determined by large assignments/projects */
+    combination_based BOOL, /* grading breakdown does not fall in exam_based or project_based catagories, grade was determined by many different things and wasn't majority based on one catagory */
+    */
     /* Tag each course review to a professor */
-    professor_id INT NOT NULL,
+    professor_id INT NOT NULL, /* not sure how to do this efficently, maybe for each course we could have a dropdown list of professors */
     FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE /* Each review should have exactly 1 professor associated with it*/
 );
 


### PR DESCRIPTION
I created two additional tables to support the functionality of the rate my professors feature in our interface. The professors table will list all of the professors in our interface. The courses_to_professors table connects professors to the courses they teach, which in turn will connect each course review to the professor who taught the course. I also added attributes to the reviews table to specify that the user writing the review took the course in a specific term and with a specific professor. Additionally, I added a few attributes in the reviews table to quantify the user's review, such as enjoyability of the course, difficulty, etc (the review metrics are still a work in progress). All in all, I think that the database in this state will provide enough information to sort the reviews on the page and explain why the user might have felt a certain way about a course. 